### PR TITLE
feat: improve PR commit messages with agent-generated summaries

### DIFF
--- a/src/agents/shared/index.ts
+++ b/src/agents/shared/index.ts
@@ -115,6 +115,7 @@ export {
     handleClarificationRequest,
     extractFeedbackResolution,
     formatFeedbackResolution,
+    extractPRSummary,
     type BugDiagnostics,
     type FeedbackResolution,
 } from './utils';

--- a/src/agents/shared/prompts.ts
+++ b/src/agents/shared/prompts.ts
@@ -639,10 +639,19 @@ ${AMBIGUITY_INSTRUCTIONS}
 
 ## Output
 
-After implementing, provide a brief summary of:
-1. Files created
-2. Files modified
-3. Any issues encountered
+After implementing, you MUST provide a PR summary in this exact format:
+
+\`\`\`pr-summary
+## Summary
+[2-4 bullet points describing what was implemented and key decisions made]
+
+## Changes
+- **[filename]**: [brief description of change]
+- **[filename]**: [brief description of change]
+[List the most important files changed - max 5-7 files]
+\`\`\`
+
+This summary will be used in the PR description and squash merge commit message, so make it informative and concise.
 
 Begin implementing the feature now.`;
 }
@@ -796,10 +805,19 @@ ${AMBIGUITY_INSTRUCTIONS}
 
 ## Output
 
-After implementing, provide a brief summary of:
-1. Files created
-2. Files modified
-3. Any issues encountered
+After implementing, you MUST provide a PR summary in this exact format:
+
+\`\`\`pr-summary
+## Summary
+[2-4 bullet points describing what was implemented and key decisions made]
+
+## Changes
+- **[filename]**: [brief description of change]
+- **[filename]**: [brief description of change]
+[List the most important files changed - max 5-7 files]
+\`\`\`
+
+This summary will be used in the PR description and squash merge commit message, so make it informative and concise.
 
 Begin implementing the feature now.`;
 }
@@ -1026,11 +1044,19 @@ ${AMBIGUITY_INSTRUCTIONS}
 
 ## Output
 
-After implementing, provide a brief summary of:
-1. Root cause that was fixed
-2. Files modified and changes made
-3. How to verify the fix works
-4. Any edge cases addressed
+After implementing, you MUST provide a PR summary in this exact format:
+
+\`\`\`pr-summary
+## Summary
+[2-4 bullet points describing: the root cause, how it was fixed, and how to verify]
+
+## Changes
+- **[filename]**: [brief description of change]
+- **[filename]**: [brief description of change]
+[List the most important files changed - max 5-7 files]
+\`\`\`
+
+This summary will be used in the PR description and squash merge commit message, so make it informative and concise.
 
 Begin implementing the bug fix now.`;
 }

--- a/src/agents/shared/utils.ts
+++ b/src/agents/shared/utils.ts
@@ -225,3 +225,26 @@ ${rows.join('\n')}
 
 Ready for re-review.`;
 }
+
+// ============================================================
+// PR SUMMARY EXTRACTION
+// ============================================================
+
+/**
+ * Extract PR summary from agent output
+ *
+ * Agents output PR summaries in this format:
+ * ```pr-summary
+ * ## Summary
+ * [bullet points]
+ *
+ * ## Changes
+ * - **file**: description
+ * ```
+ */
+export function extractPRSummary(content: string): string | null {
+    if (!content) return null;
+
+    const match = content.match(/```pr-summary\n([\s\S]*?)\n```/);
+    return match ? match[1].trim() : null;
+}


### PR DESCRIPTION
The implementer agent now generates detailed PR descriptions that become
meaningful squash merge commit messages. Previously, PRs only had generic
text like "Implements the feature described in issue #X."

Changes:
- Update implementation prompts to request structured pr-summary output
- Add extractPRSummary function to parse agent output
- Use extracted summary in PR body (above --- separator)
- Fallback to generic text if agent doesn't provide summary

The pr-summary format includes:
- Summary section with 2-4 bullet points of key changes
- Changes section listing important files modified

Closes #23