### PR TITLE
fix: prevent infinite loading state on bug reports page

### DIFF
--- a/src/client/routes/Reports/Reports.tsx
+++ b/src/client/routes/Reports/Reports.tsx
@@ -49,7 +49,8 @@ export function Reports() {
     // Determine if we should show loading state:
     // - isLoading is true when fetching without cached data
     // - reports is undefined when no data exists yet (before first fetch completes)
-    const showLoading = isLoading || reports === undefined;
+    // - Don't show loading if there's an error (show error state instead)
+    const showLoading = !error && (isLoading || reports === undefined);
 
     const deleteAllMutation = useDeleteAllReports();
 


### PR DESCRIPTION
When the API returns an error, the loading state was showing forever
instead of displaying the error message. This happened because:
1. isLoading becomes false after fetch completes
2. error is set
3. data (reports) remains undefined
4. showLoading = (false || true) = true

The fix adds a check for error before showing loading state, so errors
are properly displayed.

https://claude.ai/code/session_01QY1sm6YDga1DctnabuSyVD