### PR TITLE
fix: handle undefined date fields in report handlers for legacy documents

### DIFF
--- a/.cursor/rules/mongodb-usage.mdc
+++ b/.cursor/rules/mongodb-usage.mdc
@@ -1,138 +1,54 @@
 ---
 description: when accessing the databse or a collection in the db
-globs: 
+globs:
 alwaysApply: false
 ---
 # MongoDB Usage Guidelines
 
-## Core Principles
+**Full documentation:** [docs/mongodb-usage.md](docs/mongodb-usage.md)
 
-1. **Encapsulation**: All MongoDB operations MUST be encapsulated within the `src/server/database` folder.
-2. **No Direct MongoDB Imports**: Direct imports of `mongodb` libraries outside the database layer are STRICTLY PROHIBITED.
-3. **Clean API Layer**: The API layer (`src/apis`) must ONLY interact with the database through functions exported from the database layer.
-4. **Type Safety**: All database operations should use TypeScript interfaces for type safety.
-5. **Use ID Utilities**: Always use `@/server/utils` for ID conversion - never direct ObjectId methods.
+## Quick Reference
 
-## Required Structure
+### Core Principles
+1. All MongoDB operations in `src/server/database/collections/`
+2. Never import `mongodb` directly in API handlers
+3. Use `@/server/utils` for ID conversion
 
-Database operations must follow this structure:
-```
-/src
-  /server
-    /utils
-      /id.ts                - ID conversion utilities (toStringId, toQueryId, toDocumentId)
-      /index.ts             - Exports all utilities
-    /database
-      /index.ts             - Exports shared utilities and collection modules
-      /collections
-        /<collection-name>  - One folder per MongoDB collection
-          /types.ts         - TypeScript interfaces for the collection
-          /<collection-name>.ts - Database operations for the collection
-```
-
-## ID Handling (ObjectId vs UUID)
-
-This app supports both MongoDB ObjectId (legacy) and UUID strings (client-generated) for `_id` fields.
-
-### Required: Use Server Utilities
-
+### ID Utilities
 ```typescript
 import { toStringId, toQueryId, toDocumentId } from '@/server/utils';
+
+// API responses
+{ _id: toStringId(doc._id) }
+
+// MongoDB queries
+{ _id: toQueryId(clientId) }
+
+// Document insertion
+{ _id: toDocumentId(clientId) }
 ```
 
-| Utility | Use Case | Example |
-|---------|----------|---------|
-| `toStringId(id)` | API responses | `{ _id: toStringId(doc._id) }` |
-| `toQueryId(id)` | MongoDB queries | `{ _id: toQueryId(clientId) }` |
-| `toDocumentId(id)` | Document insertion | `{ _id: toDocumentId(clientId) }` |
+## ⚠️ CRITICAL: Schema Backward Compatibility
 
-### ❌ NEVER use direct ObjectId methods:
+**When adding new fields to schemas, existing documents won't have them. Always use optional chaining and fallbacks:**
 
 ```typescript
-// ❌ WRONG - Breaks on UUID strings
-doc._id.toHexString()          // TypeError if UUID string
-new ObjectId(clientId)          // BSONError if UUID string
-{ _id: new ObjectId(id) }       // BSONError in queries
+// ✅ CORRECT - Handle potentially missing fields
+const createdAt = doc.createdAt?.toISOString() ?? new Date().toISOString();
+const firstOccurrence = doc.firstOccurrence?.toISOString() ?? createdAt;
+const count = doc.count ?? 1;
 
-// ✅ CORRECT - Works for both formats
-toStringId(doc._id)
-toDocumentId(clientId)
-{ _id: toQueryId(id) }
+// ❌ WRONG - Assumes field always exists (crashes on legacy docs)
+const createdAt = doc.createdAt.toISOString();
 ```
 
-## Correct Usage Examples
+**When Adding New Fields:**
+1. Add as optional in TypeScript (`?`) or provide defaults
+2. Use optional chaining (`?.`) when accessing
+3. Provide fallbacks with nullish coalescing (`??`)
+4. Consider migration scripts for critical fields
 
-### 1. Defining collection types:
-```typescript
-// src/server/database/collections/exercises/types.ts
-import { ObjectId } from 'mongodb';
-
-export interface Exercise {
-  _id: ObjectId;  // Can be ObjectId or string in practice (for UUIDs)
-  userId: ObjectId;
-  // Other properties...
-}
-
-export type ExerciseCreate = Omit<Exercise, '_id'>;
-export type ExerciseUpdate = Partial<Omit<Exercise, '_id' | 'userId'>>;
-```
-
-### 2. Implementing collection operations:
-```typescript
-// src/server/database/collections/exercises/exercises.ts
-import { Collection, ObjectId } from 'mongodb';
-import { getDb } from '@/server/database';
-import { toQueryId } from '@/server/utils';
-import { Exercise } from './types';
-
-// Private function to get collection reference
-const getExercisesCollection = async (): Promise<Collection<Exercise>> => {
-  const db = await getDb();
-  return db.collection<Exercise>('exercises');
-};
-
-// Public functions for database operations
-export const findExerciseById = async (
-  exerciseId: string, 
-  userId: ObjectId | string
-): Promise<Exercise | null> => {
-  const collection = await getExercisesCollection();
-  // Use toQueryId to handle both ObjectId and UUID formats
-  return collection.findOne({ 
-    _id: toQueryId(exerciseId) as any,
-    userId: typeof userId === 'string' ? new ObjectId(userId) : userId
-  });
-};
-```
-
-### 3. Using in API layer:
-```typescript
-// src/apis/exercises/handlers/getExercise.ts
-import { exercises } from '@/server/database';
-import { toStringId } from '@/server/utils';
-import { GetExerciseRequest, GetExerciseResponse } from '../types';
-
-export const getExercise = async (
-  params: GetExerciseRequest,
-  context: { userId: string }
-): Promise<GetExerciseResponse> => {
-  try {
-    const exercise = await exercises.findExerciseById(params.exerciseId, context.userId);
-    if (!exercise) return { error: "Exercise not found" };
-    
-    // Use toStringId for response - works for both ObjectId and UUID
-    return { 
-      exercise: {
-        ...exercise,
-        _id: toStringId(exercise._id),
-        userId: toStringId(exercise.userId),
-      }
-    };
-  } catch (error) {
-    return { error: "Failed to fetch exercise" };
-  }
-};
-```
+See [docs/mongodb-usage.md](docs/mongodb-usage.md) for full details.
 
 ## What NOT To Do
 

--- a/docs/mongodb-usage.md
+++ b/docs/mongodb-usage.md
@@ -1,0 +1,268 @@
+# MongoDB Usage Guidelines
+
+This document covers all MongoDB-related patterns, including database layer organization, ID handling, and schema evolution.
+
+## Core Principles
+
+1. **Encapsulation**: All MongoDB operations MUST be encapsulated within `src/server/database`
+2. **No Direct MongoDB Imports**: Direct imports of `mongodb` outside the database layer are PROHIBITED
+3. **Clean API Layer**: The API layer (`src/apis`) must ONLY interact through the database layer
+4. **Type Safety**: All database operations should use TypeScript interfaces
+5. **Use ID Utilities**: Always use `@/server/utils` for ID conversion
+
+## Required Structure
+
+```
+/src
+  /server
+    /utils
+      /id.ts                - ID conversion utilities
+      /index.ts             - Exports all utilities
+    /database
+      /index.ts             - Exports shared utilities and collection modules
+      /collections
+        /<collection-name>  - One folder per MongoDB collection
+          /types.ts         - TypeScript interfaces for the collection
+          /<collection-name>.ts - Database operations
+```
+
+---
+
+## ID Handling (ObjectId vs UUID)
+
+This app supports both MongoDB ObjectId (legacy) and UUID strings (client-generated) for `_id` fields.
+
+### Required: Use Server Utilities
+
+```typescript
+import { toStringId, toQueryId, toDocumentId } from '@/server/utils';
+```
+
+| Utility | Use Case | Example |
+|---------|----------|---------|
+| `toStringId(id)` | API responses | `{ _id: toStringId(doc._id) }` |
+| `toQueryId(id)` | MongoDB queries | `{ _id: toQueryId(clientId) }` |
+| `toDocumentId(id)` | Document insertion | `{ _id: toDocumentId(clientId) }` |
+
+### Never Use Direct ObjectId Methods
+
+```typescript
+// BAD - Breaks on UUID strings
+doc._id.toHexString()          // TypeError if UUID string
+new ObjectId(clientId)          // BSONError if UUID string
+
+// GOOD - Works for both formats
+toStringId(doc._id)
+toQueryId(clientId)
+```
+
+---
+
+## CRITICAL: Schema Evolution & Backward Compatibility
+
+**When modifying document schemas, you MUST account for existing documents in the database that were created before the schema change.**
+
+### The Problem
+
+When you add new required fields to a schema or change field types, existing documents in the database won't have those fields. This causes runtime errors when code assumes fields exist:
+
+```typescript
+// Schema change: Added `firstOccurrence: Date` as required field
+// BUG: Existing documents don't have this field!
+const response = {
+  firstOccurrence: doc.firstOccurrence.toISOString(),  // TypeError: Cannot read properties of undefined
+};
+```
+
+### Required: Defensive Coding for All Field Access
+
+When reading documents that may have been created before a schema change:
+
+```typescript
+// CORRECT - Handle potentially missing fields
+const createdAt = doc.createdAt?.toISOString() ?? new Date().toISOString();
+const firstOccurrence = doc.firstOccurrence?.toISOString() ?? createdAt;
+const occurrenceCount = doc.occurrenceCount ?? 1;
+
+// WRONG - Assumes field always exists
+const createdAt = doc.createdAt.toISOString();  // Crashes on legacy docs
+```
+
+### Schema Evolution Checklist
+
+When adding new fields to a document schema:
+
+1. **Add fields as optional in TypeScript** (with `?`) OR provide default values
+2. **Use optional chaining (`?.`)** when accessing the field
+3. **Provide sensible fallbacks** using nullish coalescing (`??`)
+4. **Consider migration**: For critical fields, write a migration script to backfill existing documents
+5. **Test with empty/partial documents** to verify backward compatibility
+
+### Common Patterns for New Fields
+
+**Dates:**
+```typescript
+// Fallback to createdAt, then to current time
+const newDateField = doc.newDateField?.toISOString()
+  ?? doc.createdAt?.toISOString()
+  ?? new Date().toISOString();
+```
+
+**Counts:**
+```typescript
+// Default to 1 for count fields
+const count = doc.count ?? 1;
+```
+
+**Nested Objects:**
+```typescript
+// Check parent exists before accessing child
+const childValue = doc.parent?.child?.value ?? defaultValue;
+```
+
+**Arrays:**
+```typescript
+// Default to empty array
+const items = doc.items ?? [];
+```
+
+### Migration Scripts (When Needed)
+
+For important schema changes, create a migration script:
+
+```typescript
+// scripts/migrations/add-occurrence-fields.ts
+const collection = await getCollection();
+
+// Add default values to all documents missing the field
+await collection.updateMany(
+  { firstOccurrence: { $exists: false } },
+  {
+    $set: {
+      firstOccurrence: new Date(),
+      lastOccurrence: new Date(),
+      occurrenceCount: 1
+    }
+  }
+);
+```
+
+### Types vs Reality
+
+Remember: TypeScript types describe the **intended** shape of documents. The **actual** documents in production may differ due to:
+
+- Fields added after documents were created
+- Fields removed but old documents still have them
+- Type changes (string to Date, number to string)
+- Optional fields that became required
+
+**Always code defensively when reading from the database.**
+
+---
+
+## Collection Types
+
+### Defining Collection Types
+
+```typescript
+// src/server/database/collections/exercises/types.ts
+import { ObjectId } from 'mongodb';
+
+export interface Exercise {
+  _id: ObjectId;  // Can be ObjectId or string in practice
+  userId: ObjectId;
+  name: string;
+  // New fields should be optional for backward compatibility
+  newField?: string;
+}
+
+export type ExerciseCreate = Omit<Exercise, '_id'>;
+export type ExerciseUpdate = Partial<Omit<Exercise, '_id' | 'userId'>>;
+```
+
+### Implementing Collection Operations
+
+```typescript
+// src/server/database/collections/exercises/exercises.ts
+import { Collection, ObjectId } from 'mongodb';
+import { getDb } from '@/server/database';
+import { toQueryId } from '@/server/utils';
+import { Exercise } from './types';
+
+const getExercisesCollection = async (): Promise<Collection<Exercise>> => {
+  const db = await getDb();
+  return db.collection<Exercise>('exercises');
+};
+
+export const findExerciseById = async (
+  exerciseId: string,
+  userId: ObjectId | string
+): Promise<Exercise | null> => {
+  const collection = await getExercisesCollection();
+  return collection.findOne({
+    _id: toQueryId(exerciseId) as any,
+    userId: typeof userId === 'string' ? new ObjectId(userId) : userId
+  });
+};
+```
+
+### Using in API Layer
+
+```typescript
+// src/apis/exercises/handlers/getExercise.ts
+import { exercises } from '@/server/database';
+import { toStringId } from '@/server/utils';
+
+export const getExercise = async (params, context) => {
+  const exercise = await exercises.findExerciseById(params.id, context.userId);
+  if (!exercise) return { error: "Not found" };
+
+  // Handle potentially missing fields with fallbacks
+  return {
+    exercise: {
+      _id: toStringId(exercise._id),
+      name: exercise.name,
+      newField: exercise.newField ?? 'default',  // Backward compatible
+    }
+  };
+};
+```
+
+---
+
+## What NOT To Do
+
+### Never import MongoDB directly in API layer
+
+```typescript
+// WRONG
+import { MongoClient } from 'mongodb';
+const client = new MongoClient(process.env.MONGODB_URI!);
+```
+
+### Never access collections directly from API layer
+
+```typescript
+// WRONG
+import { getDb } from '@/server/database';
+const db = await getDb();
+const collection = db.collection('exercises');
+```
+
+### Never assume fields exist on documents
+
+```typescript
+// WRONG - Will crash on documents created before the field was added
+const value = doc.newField.toString();
+
+// CORRECT
+const value = doc.newField?.toString() ?? 'default';
+```
+
+---
+
+## Reference
+
+- **Server Utilities**: `src/server/utils/id.ts`
+- **Database Layer**: `src/server/database/`
+- **Mutation Guidelines**: `docs/react-query-mutations.md`

--- a/src/apis/reports/handlers/getReport.ts
+++ b/src/apis/reports/handlers/getReport.ts
@@ -18,6 +18,12 @@ export const getReport = async (
         }
 
         // Convert to client format
+        // Handle legacy reports that may not have all date fields
+        const createdAt = reportDoc.createdAt?.toISOString() ?? new Date().toISOString();
+        const updatedAt = reportDoc.updatedAt?.toISOString() ?? createdAt;
+        const firstOccurrence = reportDoc.firstOccurrence?.toISOString() ?? createdAt;
+        const lastOccurrence = reportDoc.lastOccurrence?.toISOString() ?? firstOccurrence;
+
         const reportClient = {
             _id: toStringId(reportDoc._id),
             type: reportDoc.type,
@@ -35,20 +41,20 @@ export const getReport = async (
             performanceEntries: reportDoc.performanceEntries,
             investigation: reportDoc.investigation ? {
                 ...reportDoc.investigation,
-                investigatedAt: reportDoc.investigation.investigatedAt.toISOString(),
+                investigatedAt: reportDoc.investigation.investigatedAt?.toISOString() ?? createdAt,
             } : undefined,
             duplicateOf: reportDoc.duplicateOf ? toStringId(reportDoc.duplicateOf) : undefined,
-            occurrenceCount: reportDoc.occurrenceCount,
-            firstOccurrence: reportDoc.firstOccurrence.toISOString(),
-            lastOccurrence: reportDoc.lastOccurrence.toISOString(),
+            occurrenceCount: reportDoc.occurrenceCount ?? 1,
+            firstOccurrence,
+            lastOccurrence,
             errorKey: reportDoc.errorKey,
             githubIssueUrl: reportDoc.githubIssueUrl,
             githubIssueNumber: reportDoc.githubIssueNumber,
             githubProjectItemId: reportDoc.githubProjectItemId,
             githubPrUrl: reportDoc.githubPrUrl,
             githubPrNumber: reportDoc.githubPrNumber,
-            createdAt: reportDoc.createdAt.toISOString(),
-            updatedAt: reportDoc.updatedAt.toISOString(),
+            createdAt,
+            updatedAt,
         };
 
         return { report: reportClient };

--- a/src/apis/reports/handlers/getReports.ts
+++ b/src/apis/reports/handlers/getReports.ts
@@ -32,38 +32,46 @@ export const getReports = async (
         const reportDocs = await reports.findReports(filters, sortBy, sortOrder);
 
         // Convert to client format
-        const reportsClient = reportDocs.map((doc) => ({
-            _id: toStringId(doc._id),
-            type: doc.type,
-            status: doc.status,
-            description: doc.description,
-            screenshot: doc.screenshot,
-            sessionLogs: doc.sessionLogs,
-            userInfo: doc.userInfo,
-            browserInfo: doc.browserInfo,
-            route: doc.route,
-            networkStatus: doc.networkStatus,
-            stackTrace: doc.stackTrace,
-            errorMessage: doc.errorMessage,
-            category: doc.category,
-            performanceEntries: doc.performanceEntries,
-            investigation: doc.investigation ? {
-                ...doc.investigation,
-                investigatedAt: doc.investigation.investigatedAt.toISOString(),
-            } : undefined,
-            duplicateOf: doc.duplicateOf ? toStringId(doc.duplicateOf) : undefined,
-            occurrenceCount: doc.occurrenceCount,
-            firstOccurrence: doc.firstOccurrence.toISOString(),
-            lastOccurrence: doc.lastOccurrence.toISOString(),
-            errorKey: doc.errorKey,
-            githubIssueUrl: doc.githubIssueUrl,
-            githubIssueNumber: doc.githubIssueNumber,
-            githubProjectItemId: doc.githubProjectItemId,
-            githubPrUrl: doc.githubPrUrl,
-            githubPrNumber: doc.githubPrNumber,
-            createdAt: doc.createdAt.toISOString(),
-            updatedAt: doc.updatedAt.toISOString(),
-        }));
+        // Handle legacy reports that may not have all date fields
+        const reportsClient = reportDocs.map((doc) => {
+            const createdAt = doc.createdAt?.toISOString() ?? new Date().toISOString();
+            const updatedAt = doc.updatedAt?.toISOString() ?? createdAt;
+            const firstOccurrence = doc.firstOccurrence?.toISOString() ?? createdAt;
+            const lastOccurrence = doc.lastOccurrence?.toISOString() ?? firstOccurrence;
+
+            return {
+                _id: toStringId(doc._id),
+                type: doc.type,
+                status: doc.status,
+                description: doc.description,
+                screenshot: doc.screenshot,
+                sessionLogs: doc.sessionLogs,
+                userInfo: doc.userInfo,
+                browserInfo: doc.browserInfo,
+                route: doc.route,
+                networkStatus: doc.networkStatus,
+                stackTrace: doc.stackTrace,
+                errorMessage: doc.errorMessage,
+                category: doc.category,
+                performanceEntries: doc.performanceEntries,
+                investigation: doc.investigation ? {
+                    ...doc.investigation,
+                    investigatedAt: doc.investigation.investigatedAt?.toISOString() ?? createdAt,
+                } : undefined,
+                duplicateOf: doc.duplicateOf ? toStringId(doc.duplicateOf) : undefined,
+                occurrenceCount: doc.occurrenceCount ?? 1,
+                firstOccurrence,
+                lastOccurrence,
+                errorKey: doc.errorKey,
+                githubIssueUrl: doc.githubIssueUrl,
+                githubIssueNumber: doc.githubIssueNumber,
+                githubProjectItemId: doc.githubProjectItemId,
+                githubPrUrl: doc.githubPrUrl,
+                githubPrNumber: doc.githubPrNumber,
+                createdAt,
+                updatedAt,
+            };
+        });
 
         return { reports: reportsClient };
     } catch (error: unknown) {

--- a/src/apis/reports/handlers/updateInvestigation.ts
+++ b/src/apis/reports/handlers/updateInvestigation.ts
@@ -81,6 +81,12 @@ export const updateInvestigation = async (
         }
 
         // Convert to client format
+        // Handle legacy reports that may not have all date fields
+        const createdAt = reportDoc.createdAt?.toISOString() ?? new Date().toISOString();
+        const updatedAt = reportDoc.updatedAt?.toISOString() ?? createdAt;
+        const firstOccurrence = reportDoc.firstOccurrence?.toISOString() ?? createdAt;
+        const lastOccurrence = reportDoc.lastOccurrence?.toISOString() ?? firstOccurrence;
+
         const reportClient = {
             _id: toStringId(reportDoc._id),
             type: reportDoc.type,
@@ -98,20 +104,20 @@ export const updateInvestigation = async (
             performanceEntries: reportDoc.performanceEntries,
             investigation: reportDoc.investigation ? {
                 ...reportDoc.investigation,
-                investigatedAt: reportDoc.investigation.investigatedAt.toISOString(),
+                investigatedAt: reportDoc.investigation.investigatedAt?.toISOString() ?? createdAt,
             } : undefined,
             duplicateOf: reportDoc.duplicateOf ? toStringId(reportDoc.duplicateOf) : undefined,
-            occurrenceCount: reportDoc.occurrenceCount,
-            firstOccurrence: reportDoc.firstOccurrence.toISOString(),
-            lastOccurrence: reportDoc.lastOccurrence.toISOString(),
+            occurrenceCount: reportDoc.occurrenceCount ?? 1,
+            firstOccurrence,
+            lastOccurrence,
             errorKey: reportDoc.errorKey,
             githubIssueUrl: reportDoc.githubIssueUrl,
             githubIssueNumber: reportDoc.githubIssueNumber,
             githubProjectItemId: reportDoc.githubProjectItemId,
             githubPrUrl: reportDoc.githubPrUrl,
             githubPrNumber: reportDoc.githubPrNumber,
-            createdAt: reportDoc.createdAt.toISOString(),
-            updatedAt: reportDoc.updatedAt.toISOString(),
+            createdAt,
+            updatedAt,
         };
 
         return { report: reportClient };

--- a/src/apis/reports/handlers/updateReportStatus.ts
+++ b/src/apis/reports/handlers/updateReportStatus.ts
@@ -27,6 +27,12 @@ export const updateReportStatus = async (
         }
 
         // Convert to client format
+        // Handle legacy reports that may not have all date fields
+        const createdAt = reportDoc.createdAt?.toISOString() ?? new Date().toISOString();
+        const updatedAt = reportDoc.updatedAt?.toISOString() ?? createdAt;
+        const firstOccurrence = reportDoc.firstOccurrence?.toISOString() ?? createdAt;
+        const lastOccurrence = reportDoc.lastOccurrence?.toISOString() ?? firstOccurrence;
+
         const reportClient = {
             _id: toStringId(reportDoc._id),
             type: reportDoc.type,
@@ -44,20 +50,20 @@ export const updateReportStatus = async (
             performanceEntries: reportDoc.performanceEntries,
             investigation: reportDoc.investigation ? {
                 ...reportDoc.investigation,
-                investigatedAt: reportDoc.investigation.investigatedAt.toISOString(),
+                investigatedAt: reportDoc.investigation.investigatedAt?.toISOString() ?? createdAt,
             } : undefined,
             duplicateOf: reportDoc.duplicateOf ? toStringId(reportDoc.duplicateOf) : undefined,
-            occurrenceCount: reportDoc.occurrenceCount,
-            firstOccurrence: reportDoc.firstOccurrence.toISOString(),
-            lastOccurrence: reportDoc.lastOccurrence.toISOString(),
+            occurrenceCount: reportDoc.occurrenceCount ?? 1,
+            firstOccurrence,
+            lastOccurrence,
             errorKey: reportDoc.errorKey,
             githubIssueUrl: reportDoc.githubIssueUrl,
             githubIssueNumber: reportDoc.githubIssueNumber,
             githubProjectItemId: reportDoc.githubProjectItemId,
             githubPrUrl: reportDoc.githubPrUrl,
             githubPrNumber: reportDoc.githubPrNumber,
-            createdAt: reportDoc.createdAt.toISOString(),
-            updatedAt: reportDoc.updatedAt.toISOString(),
+            createdAt,
+            updatedAt,
         };
 
         return { report: reportClient };


### PR DESCRIPTION
- Add optional chaining and fallbacks for date fields that may not exist
  on legacy report documents (firstOccurrence, lastOccurrence, etc.)
- Add comprehensive MongoDB schema evolution guidelines to docs
- Update CLAUDE.md with backward compatibility requirements

https://claude.ai/code/session_019Szg49eYjTcCC1dkGd587H