### PR TITLE
test: verify E2E CI catches logic regressions (intentional 2 failures)

### DIFF
--- a/src/agents/shared/utils.ts
+++ b/src/agents/shared/utils.ts
@@ -125,7 +125,7 @@ export function extractClarificationFromResult(result: {
     const output = result.structuredOutput as Record<string, unknown>;
 
     // Check explicit needsClarification flag
-    if (output.needsClarification !== true) {
+    if (output.needsClarification !== true || true) {
         return null;
     }
 

--- a/src/server/workflow-service/phase.ts
+++ b/src/server/workflow-service/phase.ts
@@ -33,7 +33,7 @@ export async function advanceImplementationPhase(
 
     const adapter = await getInitializedAdapter();
 
-    await adapter.setImplementationPhase(item.itemId, nextPhase);
+    // await adapter.setImplementationPhase(item.itemId, nextPhase);
     await adapter.updateItemStatus(item.itemId, toStatus);
 
     if (adapter.hasReviewStatusField() && item.reviewStatus) {


### PR DESCRIPTION
## Summary
Intentionally breaks 2 real logic paths to verify E2E tests catch regressions:
- **`src/agents/shared/utils.ts`**: Clarification detection always returns null (`|| true` added)
- **`src/server/workflow-service/phase.ts`**: Phase field never gets set (line commented out)

Will close after verifying E2E job shows 2 failures while other 4 checks pass.

## Expected result
- `clarification.e2e.test.ts` FAILS — clarification never detected
- `multi-phase.e2e.test.ts` FAILS — phase never advances
- Other 5 tests pass
- TypeScript, ESLint, Circular, Unused all pass